### PR TITLE
Repair images menu

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -1,9 +1,9 @@
 .our-card {
   width: 100%;
   margin: 60px 0px;
-  display: flex;
   padding-bottom: 60px;
   border-bottom: 2px solid #184d47;
+  display: flex;
 }
 
 .our-card-body {
@@ -16,6 +16,14 @@
     h3 {
       margin-bottom: 20px;
     }
+}
+
+
+.our-card-image {
+  width: 600px;
+  height: 420px;
+  background-size: cover;
+  background-repeat: no-repeat;
 }
 
 // cards for the my menu page

--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -7,17 +7,17 @@
 }
 
 .our-card-body {
-  padding: 50px 70px;
+  padding: 0px 70px;
   background-color: white;
   margin-left: -40px;
   line-height: 30px;
   clip-path: polygon( 5% 0%, 100% 0%, 100% 100%, 0% 100%);
 
     h3 {
+      margin-top: 10px;
       margin-bottom: 20px;
     }
 }
-
 
 .our-card-image {
   width: 600px;
@@ -25,6 +25,26 @@
   background-size: cover;
   background-repeat: no-repeat;
 }
+
+.our-card-title {
+  margin: 30px 0px;
+  height: 73px;
+  overflow: scroll;
+}
+
+.our-card-author {
+  margin-bottom: 10px;
+  height: 90px;
+  overflow: scroll;
+}
+
+.our-card-text {
+  height: 90px;
+  overflow: scroll;
+  margin-bottom: 20px;
+}
+
+
 
 // cards for the my menu page
 

--- a/app/assets/stylesheets/pages/_weekly_menu.scss
+++ b/app/assets/stylesheets/pages/_weekly_menu.scss
@@ -2,6 +2,9 @@
   display: flex;
   justify-content: space-between;
   align-items: baseline;
+    h1 {
+      margin-bottom: 0px;
+    }
 }
 
 
@@ -52,6 +55,8 @@
     display: none;
   }
 }
+
+
 
 /*tablets and bigger*/
 @media(min-width: 576px) and (max-width:991px) {

--- a/app/assets/stylesheets/pages/_weekly_menu.scss
+++ b/app/assets/stylesheets/pages/_weekly_menu.scss
@@ -23,14 +23,41 @@
 
 /*landscape phones and smaller*/
 @media (max-width: 575px) {
-  .our-card-image {
-    width: 200px;
+
+  #menu-page-title {
+    width: 90%;
+    flex-flow: row wrap;
+      h1 {
+        font-size: 40px;
+    }
   }
 
+  .our-card {
+    flex-flow: row wrap;
+  }
+
+  .our-card-body {
+    padding: 10px 10px;
+    margin: 10px 10px;
+    clip-path: polygon( 0% 0%, 100% 0%, 100% 100%, 0% 100%);
+  }
+
+  .our-card-image {
+    width: 300px;
+    height: 180px;
+    margin: 0px auto;
+  }
+
+  #number {
+    display: none;
+  }
 }
 
 /*tablets and bigger*/
 @media(min-width: 576px) and (max-width:991px) {
+    .our-card {
+    flex-flow: row wrap;
+  }
 
 }
 

--- a/app/views/menus/weekly_menu.html.erb
+++ b/app/views/menus/weekly_menu.html.erb
@@ -5,7 +5,7 @@
 
       <!-- button to save the week menu only for signed-in users -->
       <% if user_signed_in? %>
-       <%= link_to "Save this meal plan",week_menus_path(menus: @menus.map{|menu| menu.id}), method: :post, class: "btn btn-lg btn-red mt-3" %>
+       <%= link_to "Save this meal plan",week_menus_path(menus: @menus.map{|menu| menu.id}), method: :post, class: "btn btn-md btn-red mt-3" %>
       <% end %>
     </div>
 
@@ -19,11 +19,17 @@
               <h1><%= @counter %> </h1>
             </div>
             <div class="our-card-body">
-              <h3 class="card-title"><strong><%= recipe.title %></strong></h3>
-              <p class="card-text"><strong>Author</strong><br><%= recipe.author %></p>
-              <p class="card-text"><strong>Ingredients</strong><br>
-                <%= recipe.ingredients_list.join(" - ") %>
-              </p>
+              <div class="our-card-title">
+                <h3 class="card-title"><strong><%= recipe.title %></strong></h3>
+              </div>
+              <div class="our-card-author">
+                <p class="card-text"><strong>Author</strong><br><%= recipe.author %></p>
+              </div>
+              <div class="our-card-text">
+                <p class="card-text"><strong>Ingredients</strong><br>
+                  <%= recipe.ingredients_list.join(" - ") %>
+                </p>
+              </div>
               <%= link_to "Go to recipe", recipe_path(recipe), class: "btn btn-transparent"%>
             </div>
           </div>

--- a/app/views/menus/weekly_menu.html.erb
+++ b/app/views/menus/weekly_menu.html.erb
@@ -9,7 +9,7 @@
       <% end %>
     </div>
 
-    <div class="recipe-cards">
+    <div id="recipe-cards">
 
       <% @menus.each do |recipe| %>
         <% @counter += 1  %>
@@ -21,7 +21,7 @@
             <div class="our-card-body">
               <h3 class="card-title"><strong><%= recipe.title %></strong></h3>
               <p class="card-text"><strong>Author</strong><br><%= recipe.author %></p>
-              <p class="card-text"><strong>Ingedrients</strong><br>
+              <p class="card-text"><strong>Ingredients</strong><br>
                 <%= recipe.ingredients_list.join(" - ") %>
               </p>
               <%= link_to "Go to recipe", recipe_path(recipe), class: "btn btn-transparent"%>
@@ -29,5 +29,7 @@
           </div>
       <% end %>
     </div>
+
+
   </div>
 </div>


### PR DESCRIPTION
repaired images and fixed media queries

set several divs so that text inside each card has the same proportion, put ingredients and titles in overflow scroll we can also do hidden

<img width="1314" alt="Schermata 2021-05-04 alle 17 33 28" src="https://user-images.githubusercontent.com/78612829/117029348-d929d480-acfe-11eb-9f30-00b7a9e1f136.png">

<img width="859" alt="Schermata 2021-05-04 alle 17 34 05" src="https://user-images.githubusercontent.com/78612829/117029441-ef379500-acfe-11eb-960f-f8645a04d6cb.png">

<img width="436" alt="Schermata 2021-05-04 alle 17 35 03" src="https://user-images.githubusercontent.com/78612829/117029558-12fadb00-acff-11eb-8410-9145c3e45f34.png">
