### PR TITLE
Changing day style

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -29,12 +29,19 @@
 }
 
 .our-card-title {
-  margin: 30px 0px;
+  margin-top: 30px;
+  margin-bottom: 20px;
+  display: flex;
+  justify-content: space-between;
+  h3 {
+    margin-bottom: 0px;
+  }
 }
 
 .our-card-author {
   margin-bottom: 10px;
-  height: 90px;
+  height: 60px;
+  overflow: hidden;
 }
 
 .our-card-text {

--- a/app/views/menus/weekly_menu.html.erb
+++ b/app/views/menus/weekly_menu.html.erb
@@ -4,7 +4,7 @@
       <div id="save-menu-option">
         <h1>Suggested weekly meal plan</h1>
         <!-- refreshing the search with the original queries -- ingredients chosen by user -->
-        <%= link_to "Try different recipes", weekly_menu_path(q: @params_q, qq: @params_qq, x: @params_x, xx: @params_xx), class: "btn btn-sm btn-transparent mb-3" %>
+        <%= link_to "Change menu", weekly_menu_path(q: @params_q, qq: @params_qq, x: @params_x, xx: @params_xx), class: "btn btn-sm btn-transparent mb-3" %>
       </div>
       <% if user_signed_in? %>
         <%= button_to "Save it!",week_menus_path(menus: @menus.map{|menu| menu.id}), class: "btn btn-red mb-3" %>
@@ -26,7 +26,11 @@
             <div class="our-card-body">
               <div class="our-card-title">
                 <!-- button for shuffling single recipes - currently only showing message "Dont be picky" -->
-                <h3 class="card-title"><strong><%= recipe.title %></strong>   <span><a class="" id="listened-btn-<%= @counter %>"><i class="fas fa-sync-alt" style="color: #c64756; font-size: 20px"></i></a></span></h3>
+                <div class="title-prep-time">
+                  <h3 class="card-title"><strong><%= recipe.title %></strong></h3>
+                  <p><i class="far fa-clock"></i> <%= recipe.time %> mins</p>
+                </div>
+                <a class="mt-2" id="listened-btn-<%= @counter %>"><i class="fas fa-sync-alt" style="color: #c64756; font-size: 20px"></i></a>
               </div>
               <div class="our-card-author">
                 <p class="card-text"><strong>Author</strong><br><%= recipe.author %></p>

--- a/app/views/menus/weekly_menu.html.erb
+++ b/app/views/menus/weekly_menu.html.erb
@@ -21,7 +21,7 @@
           <div class="our-card" id="our-card-<%= @counter %>">
             <img class="our-card-image" src="<%= recipe.img_url %>" alt="Card image cap">
             <div id="number">
-              <h2><em>day</em><span style="font-size: 45px"> <%= @counter %></span></h2>
+              <h2>day<span style="font-size: 45px"> <%= @counter %></span></h2>
             </div>
             <div class="our-card-body">
               <div class="our-card-title">


### PR DESCRIPTION
changed "day" from italic to normal
put shuffling icon in next to title with a flexbox dynamic
temporarily changed the name of "suffling entire menu" to see whether it makes it less crowded
added prep time

<img width="1319" alt="Schermata 2021-05-05 alle 18 16 29" src="https://user-images.githubusercontent.com/78612829/117174459-05605680-adce-11eb-851a-08d5ae95510d.png">
